### PR TITLE
Take out the exception catching / hiding

### DIFF
--- a/src/Commands/MakeDatabase.php
+++ b/src/Commands/MakeDatabase.php
@@ -143,15 +143,7 @@ class MakeDatabase extends BaseCommand
      */
     protected function makeDatabase()
     {
-        try {
-            $this->mangler->makeDatabase();
-        } catch (Exception $exception) {
-            dd('halted for normal Exception');
-            $this->error('! ' . $exception->getMessage());
-        } catch (PDOException $exception) {
-            dd('halted for PDO');
-            $this->error('! ' . $exception->getMessage());
-        }
+        $this->mangler->makeDatabase();
     }
 
     /**


### PR DESCRIPTION
First, PDOException will never be caught because it is an Exception.

Second, the dd's hide the message so it's not great.

Just let the exceptions throw and bomb the terminal for now.